### PR TITLE
Correção do search retornando o total depois da paginação

### DIFF
--- a/backend/src/Repository/CategoryRepository.php
+++ b/backend/src/Repository/CategoryRepository.php
@@ -27,6 +27,9 @@ class CategoryRepository extends EntityRepository
                 ->setParameter('search', '%' . $search->term . '%');
         }
 
+        $totalQb = clone $qb;
+        $total = (int) $totalQb->select('COUNT(c.id)')->getQuery()->getSingleScalarResult();
+
         // Sorting
         if (!empty($search->sortBy)) {
             $qb->orderBy('c.' . $search->sortBy, $search->sortOrder);
@@ -39,8 +42,6 @@ class CategoryRepository extends EntityRepository
         // Get paginated results
         $query = $qb->getQuery();
         $categories = $query->getResult();
-
-        $total = count($categories);
 
         return [
             'data' =>  array_map(fn($category) => $category->jsonSerialize(), $categories),

--- a/backend/src/Repository/PostRepository.php
+++ b/backend/src/Repository/PostRepository.php
@@ -43,6 +43,9 @@ class PostRepository
                 ->setParameter('search', '%' . $search->term . '%');
         }
 
+        $totalQb = clone $qb;
+        $total = (int) $totalQb->select('COUNT(c.id)')->getQuery()->getSingleScalarResult();
+
         // Sorting
         if (!empty($search->sortBy)) {
             $qb->orderBy('c.' . $search->sortBy, $search->sortOrder);
@@ -55,8 +58,6 @@ class PostRepository
         // Get paginated results
         $query = $qb->getQuery();
         $posts = $query->getResult();
-
-        $total = count($posts);
 
         return [
             'data' =>  array_map(fn($post) => $post->jsonSerialize(), $posts),


### PR DESCRIPTION
# Correção do search retornando o total depois da paginação

## #66 

## Change log:
- Clone da query para contagem das entradas antes da paginação

## Checklist:
- [x] O código está escrito em inglês
- [x] Sem warnings ou erros (console, ou logs do back end)
- [ ] Estilizações estão responsivas para smartphones e desktop (se aplicável)
- [ ] Swagger atualizado (se aplicável)
