### PR TITLE
Listagem e filtro por tags

### DIFF
--- a/backend/src/Controller/TagController.php
+++ b/backend/src/Controller/TagController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\DTO\SearchDTO;
 use App\Service\TagService;
 use App\Trait\HttpResponse;
 use Nyholm\Psr7\Response;
@@ -21,7 +22,7 @@ class TagController
     public function searchTags(ServerRequest $req): Response
     {
         $queryParams = $req->getQueryParams();
-        $search = $queryParams['search'] ?? '';
+        $search = new SearchDTO($queryParams);
 
         $result = $this->tagService->searchTags($search);
 

--- a/backend/src/Controller/TagController.php
+++ b/backend/src/Controller/TagController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Controller;
+
+use App\Service\TagService;
+use App\Trait\HttpResponse;
+use Nyholm\Psr7\Response;
+use Nyholm\Psr7\ServerRequest;
+
+class TagController
+{
+    use HttpResponse;
+
+    private TagService $tagService;
+
+    public function __construct(TagService $tagService)
+    {
+        $this->tagService = $tagService;
+    }
+
+    public function searchTags(ServerRequest $req): Response
+    {
+        $queryParams = $req->getQueryParams();
+        $search = $queryParams['search'] ?? '';
+
+        $result = $this->tagService->searchTags($search);
+
+        return $this->ok($result);
+    }
+}

--- a/backend/src/DI/Slim.php
+++ b/backend/src/DI/Slim.php
@@ -8,15 +8,18 @@ use App\Controller\CategoryController;
 use App\Controller\CommentController;
 use App\Controller\PostController;
 use App\Controller\UserController;
+use App\Controller\TagController;
 use App\Domain\Category;
 use App\Domain\Comment;
+use App\Domain\Tag;
 use App\Domain\User;
 use App\Middleware\AuthMiddleware;
 use App\Repository\CategoryRepository;
 use App\Repository\CommentRepository;
 use App\Repository\PostRepository;
+use App\Repository\TagRepository;
 use App\Repository\UserRepository;
-use App\Service\{AuthService, CategoryService, CommentService, MailerService, PostService, UserService};
+use App\Service\{AuthService, CategoryService, CommentService, MailerService, PostService, TagService, UserService};
 use Doctrine\ORM\EntityManager;
 use Nyholm\Psr7\Response;
 use Psr\Container\ContainerInterface;
@@ -89,6 +92,13 @@ final class Slim implements ServiceProvider
                 $c->get(EntityManager::class)->getClassMetadata(Comment::class)
             );
         });
+
+        $c->set(TagRepository::class, static function (ContainerInterface $c): TagRepository {
+            return new TagRepository(
+                $c->get(EntityManager::class),
+                $c->get(EntityManager::class)->getClassMetadata(Tag::class)
+            );
+        });
     }
 
     private function provideServices(Container $c): void
@@ -126,6 +136,10 @@ final class Slim implements ServiceProvider
                 $c->get(UserRepository::class)
             );
         });
+
+        $c->set(TagService::class, static function (ContainerInterface $c): TagService {
+            return new TagService($c->get(TagRepository::class));
+        });
     }
 
     private function provideControllers(Container $c): void
@@ -152,6 +166,10 @@ final class Slim implements ServiceProvider
                 $c->get(UserService::class),
                 $c->get(ValidatorInterface::class)
             );
+        });
+
+        $c->set(TagController::class, static function (ContainerInterface $c): TagController {
+            return new TagController($c->get(TagService::class));
         });
     }
 

--- a/backend/src/DTO/PostSearchDTO.php
+++ b/backend/src/DTO/PostSearchDTO.php
@@ -9,4 +9,5 @@ class PostSearchDTO extends SearchDTO
     use AutoMapper;
 
     public ?int $categoryId;
+    public ?int $tagId;
 }

--- a/backend/src/Repository/CommentRepository.php
+++ b/backend/src/Repository/CommentRepository.php
@@ -22,9 +22,9 @@ class CommentRepository
     public function getPostComments(int $postId, ?int $commentId = null): array
     {
         $conn = $this->em->getConnection();
-    
+
         $commentCondition = $commentId ? 'AND c.id = :commentId' : 'AND c.parent_comment_id IS NULL';
-    
+
         $sql = <<<SQL
             WITH RECURSIVE comment_tree AS (
                 SELECT 
@@ -66,24 +66,24 @@ class CommentRepository
             SELECT * FROM comment_tree
             ORDER BY depth, created_at ASC;
         SQL;
-    
+
         $stmt = $conn->prepare($sql);
         $stmt->bindValue("postId", $postId);
-    
+
         if ($commentId) {
             $stmt->bindValue("commentId", $commentId);
         }
-    
+
         $resultSet = $stmt->executeQuery()->fetchAllAssociative();
-    
+
         if ($commentId && empty($resultSet)) {
             throw new \Exception("Comment not found");
         }
-    
+
         $comments = $this->buildHierarchy($resultSet);
-    
+
         return $commentId ? ($comments[0] ?? []) : $comments;
-    }    
+    }
 
     public function save(Comment $comment)
     {
@@ -113,7 +113,7 @@ class CommentRepository
                 'id' => $comment['user_id'],
                 'fullName' => $comment['fullName'],
                 'username' => $comment['username'],
-                'avatar' => $comment['avatar'] ? "/user/avatar/" . $comment['user_id'] : null,
+                'avatar' => $comment['avatar'] ? "/user/avatar/" . $comment['user_id'] . "/" . $comment['avatar'] : null,
             ];
 
             $commentsById[$comment['id']] = [

--- a/backend/src/Repository/PostRepository.php
+++ b/backend/src/Repository/PostRepository.php
@@ -34,26 +34,33 @@ class PostRepository
 
     public function search(PostSearchDTO $search): array
     {
-        $qb = $this->em->getRepository(Post::class)->createQueryBuilder('c');
+        $qb = $this->em->getRepository(Post::class)->createQueryBuilder('p');
 
         // Optional term search
         if (!empty($search->term)) {
-            $qb->where('c.title LIKE :search')
+            $qb->where('p.title LIKE :search')
                 ->setParameter('search', '%' . $search->term . '%');
         }
 
         // Filter by categoryId
         if (!empty($search->categoryId)) {
-            $qb->andWhere('c.category = :categoryId')
+            $qb->andWhere('p.category = :categoryId')
                 ->setParameter('categoryId', $search->categoryId);
         }
 
+        // Filter by tagId
+        if (!empty($search->tagId)) {
+            $qb->innerJoin('p.tags', 't')
+                ->andWhere('t.id = :tagId')
+                ->setParameter('tagId', $search->tagId);
+        }
+
         $totalQb = clone $qb;
-        $total = (int) $totalQb->select('COUNT(c.id)')->getQuery()->getSingleScalarResult();
+        $total = (int) $totalQb->select('COUNT(p.id)')->getQuery()->getSingleScalarResult();
 
         // Sorting
         if (!empty($search->sortBy)) {
-            $qb->orderBy('c.' . $search->sortBy, $search->sortOrder);
+            $qb->orderBy('p.' . $search->sortBy, $search->sortOrder);
         }
 
         // Apply pagination

--- a/backend/src/Repository/TagRepository.php
+++ b/backend/src/Repository/TagRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Repository;
+
+use App\Domain\Tag;
+use Doctrine\ORM\EntityRepository;
+
+class TagRepository extends EntityRepository
+{
+    public function save(Tag $tag): Tag
+    {
+        $em = $this->getEntityManager();
+        $em->persist($tag);
+        $em->flush();
+
+        return $tag;
+    }
+
+    public function search(string $searchTerm): array
+    {
+        $qb = $this->createQueryBuilder('t');
+
+        // Optional term search
+        if (!empty($searchTerm)) {
+            $qb->where('t.name LIKE :search')
+                ->setParameter('search', '%' . $searchTerm . '%');
+        }
+
+        // Execute query and get results
+        $tags = $qb->getQuery()->getResult();
+
+        return array_map(fn($tag) => $tag->jsonSerialize(), $tags);
+    }
+
+    public function delete(Tag $tag)
+    {
+        $em = $this->getEntityManager();
+        $em->remove($tag);
+        $em->flush();
+    }
+}

--- a/backend/src/Service/TagService.php
+++ b/backend/src/Service/TagService.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Service;
+
+use App\Repository\TagRepository;
+use Exception;
+
+class TagService
+{
+    private TagRepository $tagRepository;
+
+    public function __construct(TagRepository $tagRepository)
+    {
+        $this->tagRepository = $tagRepository;
+    }
+
+    public function searchTags(string $searchTerm): array
+    {
+        try {
+            return $this->tagRepository->search($searchTerm);
+        } catch (\Throwable $th) {
+            throw new Exception("An error occurred while searching for tags.");
+        }
+    }
+}

--- a/backend/src/Service/TagService.php
+++ b/backend/src/Service/TagService.php
@@ -2,6 +2,7 @@
 
 namespace App\Service;
 
+use App\DTO\SearchDTO;
 use App\Repository\TagRepository;
 use Exception;
 
@@ -14,12 +15,18 @@ class TagService
         $this->tagRepository = $tagRepository;
     }
 
-    public function searchTags(string $searchTerm): array
+    public function searchTags(SearchDTO $search): array
     {
+        $search->term ??= "";
+        $search->page ??= 1;
+        $search->limit ??= 10;
+        $search->sortBy ??= 'name';
+        $search->sortOrder = strtolower($search->sortOrder ?? 'asc') === 'desc' ? 'desc' : 'asc';
+
         try {
-            return $this->tagRepository->search($searchTerm);
+            return $this->tagRepository->search($search);
         } catch (\Throwable $th) {
-            throw new Exception("An error occurred while searching for tags.");
+            throw new Exception("An error occured while searching for categories.");
         }
     }
 }

--- a/backend/src/routes.php
+++ b/backend/src/routes.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Controller\{UserController, CategoryController, CommentController, PostController};
+use App\Controller\{UserController, CategoryController, CommentController, PostController, TagController};
 use App\Middleware\AuthMiddleware;
 use Nyholm\Psr7\Response;
 use Nyholm\Psr7\Stream;
@@ -42,6 +42,10 @@ return function (App $app) {
         $app->post('/category', CategoryController::class . ':saveCategory');
         $app->put('/category/{id}', CategoryController::class . ':saveCategory');
         $app->delete('/category/{id}', CategoryController::class . ':deleteCategory');
+    })->add(AuthMiddleware::class);
+
+    $app->group('tags', function () use ($app) {
+        $app->get('/tags', TagController::class . ':searchTags');
     })->add(AuthMiddleware::class);
 
     $app->get('/swagger', function ($req, $res) {

--- a/backend/src/swagger.yaml
+++ b/backend/src/swagger.yaml
@@ -643,6 +643,52 @@ paths:
 
   #endregion
 
+  /tags:
+    get:
+      summary: "Get a list of tags"
+      parameters:
+        - in: query
+          name: search
+          required: false
+          schema:
+            type: string
+            example: "technology"
+          description: "Optional search term for tag name."
+        - in: query
+          name: page
+          required: false
+          schema:
+            type: integer
+            example: 1
+          description: "Page number for pagination, default is 1."
+        - in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+            example: 10
+          description: "Number of items per page, default is 10."
+        - in: query
+          name: sortBy
+          required: false
+          schema:
+            type: string
+            example: "name"
+          description: "Field to sort by, e.g., name."
+        - in: query
+          name: sortOrder
+          required: false
+          schema:
+            type: string
+            example: "asc"
+          description: "Sort order, either asc or desc."
+      responses:
+        "200":
+          description: Tags retrieved successfully
+        "401":
+          description: Unauthorized
+      tags:
+        - tag
 components:
   securitySchemes:
     BearerAuth:

--- a/backend/src/swagger.yaml
+++ b/backend/src/swagger.yaml
@@ -342,6 +342,13 @@ paths:
             type: integer
             example: "1"
           description: "Filter by category"
+        - in: query
+          name: tagId
+          required: false
+          schema:
+            type: integer
+            example: "1"
+          description: "Filter by tag"
       responses:
         "200":
           description: Categories retrieved successfully

--- a/backend/src/swagger.yaml
+++ b/backend/src/swagger.yaml
@@ -599,7 +599,7 @@ paths:
       summary: "Search categories with pagination and sorting"
       parameters:
         - in: query
-          name: search
+          name: term
           required: false
           schema:
             type: string
@@ -648,7 +648,7 @@ paths:
       summary: "Get a list of tags"
       parameters:
         - in: query
-          name: search
+          name: term
           required: false
           schema:
             type: string

--- a/frontend/src/components/shared/PostList.tsx
+++ b/frontend/src/components/shared/PostList.tsx
@@ -21,6 +21,7 @@ function PostList({ filter = {} }: { filter?: IPostSearchableOptions }) {
   const sortType = searchParams.get("order") ?? "newest";
   const handleSelectSortType = useCallback(
     (value: string) => setSearchParams((prev) => ({ ...prev, order: value })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
   const params: IPostSearchableOptions = useMemo(() => {
@@ -42,6 +43,7 @@ function PostList({ filter = {} }: { filter?: IPostSearchableOptions }) {
 
   useEffect(() => {
     postsResource.fetchData(params);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [params]);
 
   if (postsResource.loading && page === 1) return <PostCardsSkeleton />;

--- a/frontend/src/components/shared/PostList.tsx
+++ b/frontend/src/components/shared/PostList.tsx
@@ -1,0 +1,79 @@
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { PostsNotFound } from "./fallbacks/PostsNotFound";
+import { PostCard } from "./PostCard";
+import { PostCardsSkeleton } from "./skeletons/PostCardsSkeleton";
+import { Button } from "../ui/Button";
+import { useResource } from "../../hooks/useResource";
+import { IPostSearchableOptions } from "../../services/postService";
+import { ButtonGroup } from "../ui/ButtonGroup";
+import { useSearchParams } from "react-router-dom";
+
+const sortOptions = [
+  { label: "Relevance", value: "relevance" },
+  { label: "Newest", value: "newest" },
+];
+
+function PostList({ filter = {} }: { filter?: IPostSearchableOptions }) {
+  const { postsResource } = useResource();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [page, setPage] = useState(1);
+
+  const sortType = searchParams.get("order") ?? "newest";
+  const handleSelectSortType = useCallback(
+    (value: string) => setSearchParams((prev) => ({ ...prev, order: value })),
+    [],
+  );
+  const params: IPostSearchableOptions = useMemo(() => {
+    const returnParams: IPostSearchableOptions = {
+      limit: 5,
+      page,
+      sortBy: "createdAt",
+      sortOrder: "desc",
+    };
+    if (filter.categoryId?.trim()) returnParams.categoryId = filter.categoryId;
+    if (filter.tagId?.trim()) returnParams.tagId = filter.tagId;
+
+    return returnParams;
+  }, [page, filter.categoryId, filter.tagId]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [filter.categoryId, filter.tagId]);
+
+  useEffect(() => {
+    postsResource.fetchData(params);
+  }, [params]);
+
+  if (postsResource.loading && page === 1) return <PostCardsSkeleton />;
+
+  if (!postsResource.loading && !postsResource.data.length)
+    return <PostsNotFound description="We couldn't find any posts here!" />;
+
+  return (
+    <div className="flex flex-col space-y-6">
+      <div className="flex justify-between items-center">
+        <span>{postsResource.pagination.total} Posts</span>
+        <ButtonGroup
+          value={sortType}
+          onChange={handleSelectSortType}
+          options={sortOptions}
+        />
+      </div>
+      {postsResource.data.map((post) => (
+        <PostCard key={post.id} post={post} />
+      ))}
+      {page < postsResource.pagination.totalPages && (
+        <Button
+          onClick={() => setPage((p) => p + 1)}
+          className="m-auto"
+          color="secondary"
+        >
+          Load more
+        </Button>
+      )}
+    </div>
+  );
+}
+
+const MemoizedPostList = memo(PostList);
+export { MemoizedPostList as PostList };

--- a/frontend/src/components/shared/PostList.tsx
+++ b/frontend/src/components/shared/PostList.tsx
@@ -13,7 +13,11 @@ const sortOptions = [
   { label: "Newest", value: "newest" },
 ];
 
-function PostList({ filter = {} }: { filter?: IPostSearchableOptions }) {
+interface PostListProps {
+  filter?: IPostSearchableOptions;
+}
+
+function PostList({ filter = {} }: PostListProps) {
   const { postsResource } = useResource();
   const [searchParams, setSearchParams] = useSearchParams();
   const [page, setPage] = useState(1);

--- a/frontend/src/containers/HomeContent.tsx
+++ b/frontend/src/containers/HomeContent.tsx
@@ -1,31 +1,9 @@
-import { PostCard } from "../components/shared/PostCard";
 import { MdOutlineCheckCircleOutline, MdOutlineWhatshot } from "react-icons/md";
 import { RxArrowTopRight, RxClock } from "react-icons/rx";
 import { SmallTabs } from "../components/ui/SmallTabs";
-import { useResource } from "../hooks/useResource";
-import { useEffect, useState } from "react";
-import { Button } from "../components/ui/Button";
-import { PostsNotFound } from "../components/shared/fallbacks/PostsNotFound";
-import { PostCardsSkeleton } from "../components/shared/skeletons/PostCardsSkeleton";
+import { PostList } from "../components/shared/PostList";
 
 export function HomeContent() {
-  const { postsResource } = useResource();
-  const [page, setPage] = useState(1);
-  useEffect(() => {
-    postsResource.fetchData({
-      limit: 5,
-      page,
-      sortBy: "createdAt",
-      sortOrder: "desc",
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page]);
-
-  if (postsResource.loading && page === 1) return <PostCardsSkeleton />;
-
-  if (!postsResource.loading && !postsResource.data.length)
-    return <PostsNotFound description="Start by creating yours!" />;
-
   return (
     <div className="flex flex-col space-y-6">
       <SmallTabs
@@ -42,18 +20,7 @@ export function HomeContent() {
           },
         ]}
       />
-      {postsResource.data.map((post) => (
-        <PostCard key={post.id} post={post} />
-      ))}
-      {page < postsResource.pagination.totalPages && (
-        <Button
-          onClick={() => setPage((p) => p + 1)}
-          className="m-auto"
-          color="secondary"
-        >
-          Load more
-        </Button>
-      )}
+      <PostList />
     </div>
   );
 }

--- a/frontend/src/contexts/ResourceContext.tsx
+++ b/frontend/src/contexts/ResourceContext.tsx
@@ -32,6 +32,7 @@ export const ResourceProvider = ({ children }: ResourceProviderProps) => {
   const tagsResource = usePaginatedResource<Tag>({
     alias: "tags",
     fetch: tagService.getAll,
+    expiresIn: 1000 * 30, // 30 s
   });
   const postsResource = usePaginatedResource<Post, IPostSearchableOptions>({
     alias: "posts",

--- a/frontend/src/contexts/ResourceContext.tsx
+++ b/frontend/src/contexts/ResourceContext.tsx
@@ -6,6 +6,8 @@ import { IPaginatedResource } from "../models/IPaginatedResource";
 import { usePaginatedResource } from "../hooks/resources/usePaginatedResource";
 import { categoryService } from "../services/categoryService";
 import { IPostSearchableOptions, postService } from "../services/postService";
+import { Tag } from "../models/Tag";
+import { tagService } from "../services/tagService";
 
 interface ResourceProviderProps {
   children: React.ReactNode;
@@ -14,6 +16,7 @@ interface ResourceProviderProps {
 export interface ResourceContextType {
   categoriesResource: IPaginatedResource<Category>;
   postsResource: IPaginatedResource<Post, IPostSearchableOptions>;
+  tagsResource: IPaginatedResource<Tag>;
 }
 
 export const ResourceContext = createContext<ResourceContextType>(
@@ -26,6 +29,10 @@ export const ResourceProvider = ({ children }: ResourceProviderProps) => {
     alias: "categories",
     fetch: categoryService.getAll,
   });
+  const tagsResource = usePaginatedResource<Tag>({
+    alias: "tags",
+    fetch: tagService.getAll,
+  });
   const postsResource = usePaginatedResource<Post, IPostSearchableOptions>({
     alias: "posts",
     fetch: postService.getAll,
@@ -33,8 +40,8 @@ export const ResourceProvider = ({ children }: ResourceProviderProps) => {
   });
 
   const values = useMemo(
-    () => ({ categoriesResource, postsResource }),
-    [categoriesResource, postsResource],
+    () => ({ categoriesResource, postsResource, tagsResource }),
+    [categoriesResource, postsResource, tagsResource],
   );
 
   useEffect(() => {

--- a/frontend/src/pages/Categories.tsx
+++ b/frontend/src/pages/Categories.tsx
@@ -53,7 +53,7 @@ export function Categories() {
             options={categoriesOptions}
           />
           <div className="flex justify-between items-center">
-            <span>34 Posts</span>
+            <span>{postsResource.pagination.total} Posts</span>
             <ButtonGroup
               value={searchParams.get("order") ?? "relevance"}
               onChange={(value) =>

--- a/frontend/src/pages/Categories.tsx
+++ b/frontend/src/pages/Categories.tsx
@@ -1,27 +1,19 @@
 import { Content } from "../components/layout/Content";
 import { TrendingPosts } from "../components/shared/TrendingPosts";
 import { mockedPosts } from "../examples/mocks/mocks";
-import { PostCard } from "../components/shared/PostCard";
 import { SmallTabs } from "../components/ui/SmallTabs";
-import { ButtonGroup } from "../components/ui/ButtonGroup";
-import {
-  createSearchParams,
-  useNavigate,
-  useParams,
-  useSearchParams,
-} from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useResource } from "../hooks/useResource";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { ISelectOption } from "../models/ISelectOption";
 import { GlobalSidebar } from "../components/shared/GlobalSidebar";
-import { PostsNotFound } from "../components/shared/fallbacks/PostsNotFound";
+import { PostList } from "../components/shared/PostList";
 
 export function Categories() {
   const { id } = useParams();
   const categoryId = id ?? "";
   const navigate = useNavigate();
-  const { categoriesResource, postsResource } = useResource();
-  const [searchParams] = useSearchParams();
+  const { categoriesResource } = useResource();
   const handleSelectCategory = useCallback(
     (value: string) => navigate("/categories/" + value),
     [navigate],
@@ -34,12 +26,9 @@ export function Categories() {
       })),
     [categoriesResource.data],
   );
-  useEffect(() => {
-    const filters = categoryId ? { categoryId } : {};
-    postsResource.fetchData(filters);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  const postsFilter = useMemo(() => {
+    return { categoryId };
   }, [categoryId]);
-
   return (
     <Content.Root>
       <Content.Sidebar>
@@ -52,29 +41,7 @@ export function Categories() {
             onChange={handleSelectCategory}
             options={categoriesOptions}
           />
-          <div className="flex justify-between items-center">
-            <span>{postsResource.pagination.total} Posts</span>
-            <ButtonGroup
-              value={searchParams.get("order") ?? "relevance"}
-              onChange={(value) =>
-                navigate({
-                  search: createSearchParams({
-                    order: value,
-                  }).toString(),
-                })
-              }
-              options={[
-                { label: "Relevance", value: "relevance" },
-                { label: "Newest", value: "newest" },
-              ]}
-            />
-          </div>
-          {postsResource.data.map((post) => (
-            <PostCard key={post.id} post={post} />
-          ))}
-          {!postsResource.loading && !postsResource.data.length && (
-            <PostsNotFound description="Try another category!" />
-          )}
+          <PostList filter={postsFilter} />
         </div>
       </Content.Main>
       <Content.Sidebar>

--- a/frontend/src/pages/Tags.tsx
+++ b/frontend/src/pages/Tags.tsx
@@ -58,7 +58,7 @@ export function Tags() {
             options={tagsOptions}
           />
           <div className="flex justify-between items-center">
-            <span>34 Posts</span>
+            <span>{postsResource.pagination.total} Posts</span>
             <ButtonGroup
               value={searchParams.get("order") ?? "relevance"}
               onChange={(value) =>

--- a/frontend/src/pages/Tags.tsx
+++ b/frontend/src/pages/Tags.tsx
@@ -1,27 +1,19 @@
 import { Content } from "../components/layout/Content";
 import { TrendingPosts } from "../components/shared/TrendingPosts";
 import { mockedPosts } from "../examples/mocks/mocks";
-import { PostCard } from "../components/shared/PostCard";
 import { SmallTabs } from "../components/ui/SmallTabs";
-import { ButtonGroup } from "../components/ui/ButtonGroup";
-import {
-  createSearchParams,
-  useNavigate,
-  useParams,
-  useSearchParams,
-} from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { GlobalSidebar } from "../components/shared/GlobalSidebar";
 import { ISelectOption } from "../models/ISelectOption";
 import { useCallback, useEffect, useMemo } from "react";
 import { useResource } from "../hooks/useResource";
-import { PostsNotFound } from "../components/shared/fallbacks/PostsNotFound";
+import { PostList } from "../components/shared/PostList";
 
 export function Tags() {
   const { id } = useParams();
   const tagId = id ?? "";
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const { tagsResource, postsResource } = useResource();
+  const { tagsResource } = useResource();
   const handleSelectTag = useCallback(
     (value: string) => navigate("/tags/" + value),
     [navigate],
@@ -39,12 +31,9 @@ export function Tags() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    const filters = tagId ? { tagId } : {};
-    postsResource.fetchData(filters);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  const postsFilter = useMemo(() => {
+    return { tagId };
   }, [tagId]);
-
   return (
     <Content.Root>
       <Content.Sidebar>
@@ -57,29 +46,7 @@ export function Tags() {
             onChange={handleSelectTag}
             options={tagsOptions}
           />
-          <div className="flex justify-between items-center">
-            <span>{postsResource.pagination.total} Posts</span>
-            <ButtonGroup
-              value={searchParams.get("order") ?? "relevance"}
-              onChange={(value) =>
-                navigate({
-                  search: createSearchParams({
-                    order: value,
-                  }).toString(),
-                })
-              }
-              options={[
-                { label: "Relevance", value: "relevance" },
-                { label: "Newest", value: "newest" },
-              ]}
-            />
-          </div>
-          {postsResource.data.map((post) => (
-            <PostCard key={post.id} post={post} />
-          ))}
-          {!postsResource.loading && !postsResource.data.length && (
-            <PostsNotFound description="Try another tag!" />
-          )}
+          <PostList filter={postsFilter} />
         </div>
       </Content.Main>
       <Content.Sidebar>

--- a/frontend/src/pages/Tags.tsx
+++ b/frontend/src/pages/Tags.tsx
@@ -14,13 +14,14 @@ import { GlobalSidebar } from "../components/shared/GlobalSidebar";
 import { ISelectOption } from "../models/ISelectOption";
 import { useCallback, useEffect, useMemo } from "react";
 import { useResource } from "../hooks/useResource";
+import { PostsNotFound } from "../components/shared/fallbacks/PostsNotFound";
 
 export function Tags() {
   const { id } = useParams();
   const tagId = id ?? "";
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { tagsResource } = useResource();
+  const { tagsResource, postsResource } = useResource();
   const handleSelectTag = useCallback(
     (value: string) => navigate("/tags/" + value),
     [navigate],
@@ -37,6 +38,13 @@ export function Tags() {
     tagsResource.fetchData({ limit: 100000 });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    const filters = tagId ? { tagId } : {};
+    postsResource.fetchData(filters);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tagId]);
+
   return (
     <Content.Root>
       <Content.Sidebar>
@@ -66,9 +74,12 @@ export function Tags() {
               ]}
             />
           </div>
-          {mockedPosts.map((post) => (
+          {postsResource.data.map((post) => (
             <PostCard key={post.id} post={post} />
           ))}
+          {!postsResource.loading && !postsResource.data.length && (
+            <PostsNotFound description="Try another tag!" />
+          )}
         </div>
       </Content.Main>
       <Content.Sidebar>

--- a/frontend/src/pages/Tags.tsx
+++ b/frontend/src/pages/Tags.tsx
@@ -1,6 +1,6 @@
 import { Content } from "../components/layout/Content";
 import { TrendingPosts } from "../components/shared/TrendingPosts";
-import { academicTags, mockedPosts } from "../examples/mocks/mocks";
+import { mockedPosts } from "../examples/mocks/mocks";
 import { PostCard } from "../components/shared/PostCard";
 import { SmallTabs } from "../components/ui/SmallTabs";
 import { ButtonGroup } from "../components/ui/ButtonGroup";
@@ -11,11 +11,32 @@ import {
   useSearchParams,
 } from "react-router-dom";
 import { GlobalSidebar } from "../components/shared/GlobalSidebar";
+import { ISelectOption } from "../models/ISelectOption";
+import { useCallback, useEffect, useMemo } from "react";
+import { useResource } from "../hooks/useResource";
 
 export function Tags() {
   const { id } = useParams();
+  const tagId = id ?? "";
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const { tagsResource } = useResource();
+  const handleSelectTag = useCallback(
+    (value: string) => navigate("/tags/" + value),
+    [navigate],
+  );
+  const tagsOptions: ISelectOption[] = useMemo(
+    () =>
+      tagsResource.data.map((c) => ({
+        label: c.name,
+        value: String(c.id),
+      })),
+    [tagsResource.data],
+  );
+  useEffect(() => {
+    tagsResource.fetchData({ limit: 100000 });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   return (
     <Content.Root>
       <Content.Sidebar>
@@ -24,12 +45,9 @@ export function Tags() {
       <Content.Main>
         <div className="flex flex-col space-y-6">
           <SmallTabs
-            value={id ?? ""}
-            onChange={(value) => navigate("/tags/" + value)}
-            options={academicTags.map((tag) => ({
-              label: tag.name,
-              value: String(tag.id),
-            }))}
+            value={tagId}
+            onChange={handleSelectTag}
+            options={tagsOptions}
           />
           <div className="flex justify-between items-center">
             <span>34 Posts</span>

--- a/frontend/src/services/postService.ts
+++ b/frontend/src/services/postService.ts
@@ -27,6 +27,7 @@ function deletePost(id: number | string) {
 }
 export interface IPostSearchableOptions extends ISearchableOptions {
   categoryId?: string;
+  tagId?: string;
 }
 function getAll(options?: IPostSearchableOptions) {
   return api.get<IPaginatedResponse<Post>>("/posts", {

--- a/frontend/src/services/tagService.ts
+++ b/frontend/src/services/tagService.ts
@@ -1,0 +1,16 @@
+import { Category } from "../models/Category";
+import { IPaginatedResponse } from "../models/IPaginatedResponse";
+import { ISearchableOptions } from "../models/ISearchableOptions";
+import { api } from "./api";
+
+function getAll(options?: ISearchableOptions) {
+  return api.get<IPaginatedResponse<Category>>("/tags", {
+    params: {
+      ...options,
+    },
+  });
+}
+
+export const tagService = {
+  getAll,
+};


### PR DESCRIPTION
# Listagem e filtro por tags

## Issue: #76 

## Change log:
- Criação do fluxo básico de tags, apenas rota `/tags` com filtros e paginação
- Ajustes no frontend para listar tags e filtrar posts
- PostList component abstraindo lógica comum de paginação e filtros (verificar dependências de useMemo, useCallback e useEffects

## Checklist:

Antes de enviar seu código pra revisão verifique os requisitos abaixo:

- [x] O código está escrito em inglês
- [x] Sem warnings ou erros (console, ou logs do back end)
- [x] Estilizações estão responsivas para smartphones e desktop (se aplicável)
- [x] Swagger atualizado (se aplicável)
